### PR TITLE
Correct class name for justify-center

### DIFF
--- a/lesson04/build/index.html
+++ b/lesson04/build/index.html
@@ -34,7 +34,7 @@
       </section>
       <section
         id="mobile-menu"
-        class="top-68 justify-content-center absolute hidden w-full origin-top animate-open-menu flex-col bg-black text-5xl"
+        class="top-68 justify-center absolute hidden w-full origin-top animate-open-menu flex-col bg-black text-5xl"
       >
         <!-- <button class="text-8xl self-end px-6">
                 &times;


### PR DESCRIPTION
The class name used [ justify-content-center ] is not correct. I have updated the the code with correct class name [ justify-center ]